### PR TITLE
mfd: intel-m10-bmc: remove unneeded header

### DIFF
--- a/include/linux/mfd/intel-m10-bmc.h
+++ b/include/linux/mfd/intel-m10-bmc.h
@@ -7,7 +7,6 @@
 #ifndef __MFD_INTEL_M10_BMC_H
 #define __MFD_INTEL_M10_BMC_H
 
-#include <linux/dev_printk.h>
 #include <linux/regmap.h>
 #include <linux/rwsem.h>
 


### PR DESCRIPTION
dev_printk.h is not used directly by intel-m10-bmc.h
So do not include it.

Signed-off-by: Tom Rix <trix@redhat.com>